### PR TITLE
docs: 更新安装和运行命令以使用uv工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ docker-compose up -d
 
 ```bash
 # 安装依赖
-pip install -r requirements.txt
+uv sync
 
 # 初始化数据库
-python -c "from models import Base; from config import engine; Base.metadata.create_all(engine)"
+uv run python -c "from models import Base; from config import engine; Base.metadata.create_all(engine)"
 
 # 启动服务
-uvicorn main:app --host 0.0.0.0 --port 8000
+uv run uvicorn main:app --host 0.0.0.0 --port 8000
 ```
 
 ### GitLab 配置
@@ -227,10 +227,10 @@ LOCALE=en_US
 
 ```bash
 # 安装开发依赖
-pip install -e .
+uv sync --dev
 
 # 启动开发服务器
-uvicorn main:app --reload --host 0.0.0.0 --port 8000
+uv run uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ```
 
 ## 贡献指南

--- a/README_EN.md
+++ b/README_EN.md
@@ -103,13 +103,13 @@ docker-compose up -d
 
 ```bash
 # Install dependencies
-pip install -r requirements.txt
+uv sync
 
 # Initialize database
-python -c "from models import Base; from config import engine; Base.metadata.create_all(engine)"
+uv run python -c "from models import Base; from config import engine; Base.metadata.create_all(engine)"
 
 # Start service
-uvicorn main:app --host 0.0.0.0 --port 8000
+uv run uvicorn main:app --host 0.0.0.0 --port 8000
 ```
 
 ### GitLab Configuration
@@ -186,10 +186,10 @@ Used for service health status checking.
 
 ```bash
 # Install development dependencies
-pip install -e .
+uv sync --dev
 
 # Start development server
-uvicorn main:app --reload --host 0.0.0.0 --port 8000
+uv run uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ```
 
 ## Contributing


### PR DESCRIPTION
将README中的pip安装命令替换为uv sync，并在运行命令前添加uv run前缀，统一使用uv工具管理依赖和运行服务。同时更新了英文版README_EN.md中的相应命令。